### PR TITLE
Updated socket.io, Browser Source websocket now works!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>com.corundumstudio.socketio</groupId>
 			<artifactId>netty-socketio</artifactId>
-			<version>1.7.12</version>
+			<version>2.0.12</version>
 		</dependency>
 		<dependency>
 			<groupId>org.nanohttpd</groupId>

--- a/src/BrowserSourceServer.java
+++ b/src/BrowserSourceServer.java
@@ -60,7 +60,7 @@ public class BrowserSourceServer
             Configuration config = new Configuration();
             config.setHostname(address);
             config.setPort(socketPort);
-            config.setTransports(Transport.byName("websocket"));
+            config.setTransports(Transport.WEBSOCKET);
 
             socketServer = new SocketIOServer(config);
             socketServer.addEventListener("card_image", Object.class, new DataListener<Object>()


### PR DESCRIPTION
Browser Source refused to work on both our Linux and Windows machines running OpenJDK 21, updated w/ newer socket.io and it fixed the issues